### PR TITLE
Maintain sentences

### DIFF
--- a/examples/teeftfr-natural.ezs
+++ b/examples/teeftfr-natural.ezs
@@ -11,6 +11,10 @@ plugin = basics
 plugin = teeftfr
 
 ; [profile]
+[TEEFTSentenceTokenize]
+; [debug]
+; text = sentence
+; [profile]
 [TEEFTTokenize]
 ; [debug]
 ; text = token

--- a/src/natural-tag.js
+++ b/src/natural-tag.js
@@ -8,10 +8,11 @@ const lexicon = new Lexicon(lexiconFilename, defaultCategory);
 const rules = new RuleSet();
 const tagger = new BrillPOSTagger(lexicon, rules);
 
-const toCommonStruct = taggedWord => ({
-    token: taggedWord.token,
-    tag: [taggedWord.tag],
-});
+const toCommonStruct = taggedWords => taggedWords
+    .map(taggedWord => ({
+        token: taggedWord.token,
+        tag: [taggedWord.tag],
+    }));
 
 /**
  * POS Tagger from natural
@@ -36,7 +37,12 @@ export default function TEEFTNaturalTag(data, feed) {
     if (this.isLast()) {
         return feed.close();
     }
-    const res = tagger.tag(data);
-    feed.write([res.taggedWords.map(toCommonStruct)]);
+    const res = data // [[token]] = array of sentences [sentence]
+        .map((tokens) => {
+            const { taggedWords } = tagger.tag(tokens);
+            return taggedWords;
+        })
+        .map(toCommonStruct);
+    feed.write(res);
     feed.end();
 }

--- a/src/natural-tag.js
+++ b/src/natural-tag.js
@@ -8,8 +8,6 @@ const lexicon = new Lexicon(lexiconFilename, defaultCategory);
 const rules = new RuleSet();
 const tagger = new BrillPOSTagger(lexicon, rules);
 
-let tokens;
-
 const toCommonStruct = taggedWord => ({
     token: taggedWord.token,
     tag: [taggedWord.tag],
@@ -21,28 +19,24 @@ const toCommonStruct = taggedWord => ({
  * French pos tagging using natural (and LEFFF resources)
  *
  * @example
- *  { "token": "dans",      "tag": ["prep"] },
-    { "token": "le",        "tag": ["det"]  },
-    { "token": "cadre",     "tag": ["nc"] },
-    { "token": "du",        "tag": ["det"] },
-    { "token": "programme", "tag": ["nc"] }
-    },
+ *  [{ "token": "dans",      "tag": ["prep"] },
+     { "token": "le",        "tag": ["det"]  },
+     { "token": "cadre",     "tag": ["nc"] },
+     { "token": "du",        "tag": ["det"] },
+     { "token": "programme", "tag": ["nc"] }
+     },
+    ]
  *
  * @export
- * @param {Array<String>} data  Array of tokens (string)
- * @param {Array<Object>} feed  Array of tokens (object, with `token` and `tag`)
+ * @param {Array<Array<String>>} data  Array of arrays of tokens (string)
+ * @param {Array<Array<Object>>} feed  Array of arrays of tokens (object, with `token` and `tag`)
  * @returns
  */
 export default function TEEFTNaturalTag(data, feed) {
     if (this.isLast()) {
-        const res = tagger.tag(tokens);
-        feed.write(res.taggedWords.map(toCommonStruct));
         return feed.close();
     }
-    if (this.isFirst()) {
-        tokens = [];
-    }
-    const tokensArray = Array.isArray(data) ? data : [data];
-    tokens = tokens.concat(tokensArray);
+    const res = tagger.tag(data);
+    feed.write([res.taggedWords.map(toCommonStruct)]);
     feed.end();
 }

--- a/src/term-extractor.js
+++ b/src/term-extractor.js
@@ -83,12 +83,12 @@ export default function TEEFTExtractTerms(data, feed) {
     }
     const nounTag = this.getParam('nounTag', 'NOM');
     const adjTag = this.getParam('adjTag', 'ADJ');
+    reinitSequenceFrequency();
     let taggedTerms = [];
     const sentences = R.clone(data);
     sentences.forEach((sentence) => {
         const sentenceTaggedTerms = R.clone(sentence)
             .map(term => ({ ...term, tag: Array.isArray(term.tag) ? term.tag : [term.tag] }));
-        reinitSequenceFrequency();
         extractSentenceTerms(sentenceTaggedTerms, nounTag, adjTag);
         taggedTerms = taggedTerms.concat(sentenceTaggedTerms);
     });

--- a/src/term-extractor.js
+++ b/src/term-extractor.js
@@ -72,7 +72,7 @@ export function extractSentenceTerms(taggedTerms,
  *
  * @see https://github.com/istex/sisyphe/blob/master/src/worker/teeft/lib/termextractor.js
  * @export
- * @param {Stream}  data tagged terms
+ * @param {Stream}  data array of tagged terms
  * @param {Array<string>}   feed
  * @param {string}  [nounTag='NOM']  noun tag
  * @param {string}  [adjTag='ADJ']   adjective tag
@@ -81,10 +81,17 @@ export default function TEEFTExtractTerms(data, feed) {
     if (this.isLast()) {
         return feed.close();
     }
-    const taggedTerms = R.clone(data)
-        .map(term => ({ ...term, tag: Array.isArray(term.tag) ? term.tag : [term.tag] }));
-    reinitSequenceFrequency();
-    extractSentenceTerms(taggedTerms);
+    const nounTag = this.getParam('nounTag', 'NOM');
+    const adjTag = this.getParam('adjTag', 'ADJ');
+    let taggedTerms = [];
+    const sentences = R.clone(data);
+    sentences.forEach((sentence) => {
+        const sentenceTaggedTerms = R.clone(sentence)
+            .map(term => ({ ...term, tag: Array.isArray(term.tag) ? term.tag : [term.tag] }));
+        reinitSequenceFrequency();
+        extractSentenceTerms(sentenceTaggedTerms, nounTag, adjTag);
+        taggedTerms = taggedTerms.concat(sentenceTaggedTerms);
+    });
 
     // Compute `length` (number of words) and frequency
     // @param termSequence

--- a/src/term-extractor.js
+++ b/src/term-extractor.js
@@ -1,32 +1,22 @@
 import R from 'ramda';
 import { someBeginsWith } from './filter-tags';
 
-/**
- * Regroup multi-terms when possible (noun + noun, adjective + noun, *etc*.),
- * and computes statistics (frequency, *etc*.).
- *
- * @see https://github.com/istex/sisyphe/blob/master/src/worker/teeft/lib/termextractor.js
- * @export
- * @param {Stream}  data tagged terms
- * @param {Array<string>}   feed
- * @param {string}  [nounTag='NOM']  noun tag
- * @param {string}  [adjTag='ADJ']   adjective tag
- */
-export default function TEEFTExtractTerms(data, feed) {
-    if (this.isLast()) {
-        return feed.close();
-    }
-    const nounTag = this.getParam('nounTag', 'NOM');
-    const adjTag = this.getParam('adjTag', 'ADJ');
-    const isNoun = R.curry(someBeginsWith)([nounTag]);
-    const isAdj = R.curry(someBeginsWith)([adjTag]);
-    const taggedTerms = R.clone(data)
-        .map(term => ({ ...term, tag: Array.isArray(term.tag) ? term.tag : [term.tag] }));
-    const termFrequency = {};
+let termFrequency = {};
+let termSequence = [];
+const SEARCH = Symbol('SEARCH');
+const NOUN = Symbol('NOUN');
+
+export function reinitSequenceFrequency() {
+    termFrequency = {};
+    termSequence = [];
+}
+
+export function extractSentenceTerms(taggedTerms,
+    nounTag = 'NOM',
+    adjTag = 'ADJ',
+    isNoun = R.curry(someBeginsWith)([nounTag]),
+    isAdj = R.curry(someBeginsWith)([adjTag])) {
     let multiterm = [];
-    const termSequence = [];
-    const SEARCH = Symbol('SEARCH');
-    const NOUN = Symbol('NOUN');
     let state = SEARCH;
     taggedTerms
         .forEach((taggedTerm) => {
@@ -57,6 +47,44 @@ export default function TEEFTExtractTerms(data, feed) {
         termSequence.push(word);
         termFrequency[word] = (termFrequency[word] || 0) + 1;
     }
+    return { termSequence, termFrequency };
+}
+
+/**
+ * Regroup multi-terms when possible (noun + noun, adjective + noun, *etc*.),
+ * and computes statistics (frequency, *etc*.).
+ *
+ * @example
+ * [[[{ token: 'elle', tag: ['PRO:per'] },
+    { token: 'semble', tag: ['VER'] },
+    { token: 'se', tag: ['PRO:per'] },
+    { token: 'nourrir', tag: ['VER'] },
+    {
+        token: 'essentiellement',
+        tag: ['ADV'],
+    },
+    { token: 'de', tag: ['PRE', 'ART:def'] },
+    { token: 'plancton', tag: ['NOM'] },
+    { token: 'frais', tag: ['ADJ'] },
+    { token: 'et', tag: ['CON'] },
+    { token: 'de', tag: ['PRE', 'ART:def'] },
+    { token: 'hotdog', tag: ['UNK'] }]]]
+ *
+ * @see https://github.com/istex/sisyphe/blob/master/src/worker/teeft/lib/termextractor.js
+ * @export
+ * @param {Stream}  data tagged terms
+ * @param {Array<string>}   feed
+ * @param {string}  [nounTag='NOM']  noun tag
+ * @param {string}  [adjTag='ADJ']   adjective tag
+ */
+export default function TEEFTExtractTerms(data, feed) {
+    if (this.isLast()) {
+        return feed.close();
+    }
+    const taggedTerms = R.clone(data)
+        .map(term => ({ ...term, tag: Array.isArray(term.tag) ? term.tag : [term.tag] }));
+    reinitSequenceFrequency();
+    extractSentenceTerms(taggedTerms);
 
     // Compute `length` (number of words) and frequency
     // @param termSequence

--- a/src/tokenize.js
+++ b/src/tokenize.js
@@ -6,12 +6,12 @@ import words from 'talisman/tokenizers/words';
  * @see http://yomguithereal.github.io/talisman/tokenizers/words
  * @export
  * @param {Stream} data
- * @param {Array<string>} feed
+ * @param {Array<Array<string>>>} feed
  */
 export default function TEEFTTokenize(data, feed) {
     if (this.isLast()) {
         return feed.close();
     }
-    feed.write(words(data));
+    feed.write([words(data)]);
     feed.end();
 }

--- a/src/tokenize.js
+++ b/src/tokenize.js
@@ -12,6 +12,6 @@ export default function TEEFTTokenize(data, feed) {
     if (this.isLast()) {
         return feed.close();
     }
-    feed.write([words(data)]);
+    feed.write(data.map(words));
     feed.end();
 }

--- a/test/tests.js
+++ b/test/tests.js
@@ -454,7 +454,7 @@ describe('extract terms', () => {
     it('should compute correct frequencies', (done) => {
         const res = [];
         /* eslint-disable object-curly-newline */
-        from([[{ id: 0, token: 'elle', tag: ['PRO:per'], lemma: 'elle' },
+        from([[[{ id: 0, token: 'elle', tag: ['PRO:per'], lemma: 'elle' },
             { id: 1, token: 'semble', tag: ['VER'], lemma: 'sembler' },
             { id: 2, token: 'se', tag: ['PRO:per'], lemma: 'se' },
             { id: 3, token: 'nourrir', tag: ['VER'], lemma: 'nourrir' },
@@ -468,7 +468,7 @@ describe('extract terms', () => {
             { id: 7, token: 'frais', tag: ['ADJ'], lemma: 'frais' },
             { id: 8, token: 'et', tag: ['CON'], lemma: 'et' },
             { id: 9, token: 'de', tag: ['PRE', 'ART:def'], lemma: 'de' },
-            { id: 10, token: 'hotdog', tag: ['UNK'], lemma: 'hotdog' }]])
+            { id: 10, token: 'hotdog', tag: ['UNK'], lemma: 'hotdog' }]]])
         /* eslint-enable object-curly-newline */
             .pipe(ezs('TEEFTExtractTerms', { nounTag: '', adjTag: '' }))
             // .pipe(ezs('debug'))
@@ -492,7 +492,7 @@ describe('extract terms', () => {
     it('should decompose frequencies when in several chunks', (done) => {
         const res = [];
         /* eslint-disable object-curly-newline */
-        from([[{ id: 0, token: 'elle', tag: ['PRO:per'], lemma: 'elle' },
+        from([[[{ id: 0, token: 'elle', tag: ['PRO:per'], lemma: 'elle' },
             { id: 1, token: 'semble', tag: ['VER'], lemma: 'sembler' },
             { id: 2, token: 'se', tag: ['PRO:per'], lemma: 'se' },
             { id: 3, token: 'nourrir', tag: ['VER'], lemma: 'nourrir' },
@@ -502,12 +502,12 @@ describe('extract terms', () => {
                 lemma: 'essentiellement',
             },
             { id: 5, token: 'de', tag: ['PRE', 'ART:def'], lemma: 'de' },
-        ], [
+        ]], [[
             { id: 6, token: 'plancton', tag: ['NOM'], lemma: 'plancton' },
             { id: 7, token: 'frais', tag: ['ADJ'], lemma: 'frais' },
             { id: 8, token: 'et', tag: ['CON'], lemma: 'et' },
             { id: 9, token: 'de', tag: ['PRE', 'ART:def'], lemma: 'de' },
-            { id: 10, token: 'hotdog', tag: ['UNK'], lemma: 'hotdog' }]])
+            { id: 10, token: 'hotdog', tag: ['UNK'], lemma: 'hotdog' }]]])
         /* eslint-enable object-curly-newline */
             .pipe(ezs('TEEFTExtractTerms', { nounTag: '', adjTag: '' }))
             // .pipe(ezs('debug'))

--- a/test/tests.js
+++ b/test/tests.js
@@ -565,22 +565,21 @@ describe('sum up frequencies', () => {
     it('should sum up frequencies when in several chunks, and no lemma', (done) => {
         const res = [];
         /* eslint-disable object-curly-newline */
-        from([[[{ id: 0, token: 'elle', tag: ['PRO:per'], lemma: 'elle' },
-            { id: 1, token: 'semble', tag: ['VER'], lemma: 'sembler' },
-            { id: 2, token: 'se', tag: ['PRO:per'], lemma: 'se' },
-            { id: 3, token: 'nourrir', tag: ['VER'], lemma: 'nourrir' },
+        from([[[{ id: 0, token: 'elle', tag: ['PRO:per'] },
+            { id: 1, token: 'semble', tag: ['VER'] },
+            { id: 2, token: 'se', tag: ['PRO:per'] },
+            { id: 3, token: 'nourrir', tag: ['VER'] },
             { id: 4,
                 token: 'essentiellement',
                 tag: ['ADV'],
-                lemma: 'essentiellement',
             },
             { id: 5, token: 'de', tag: ['PRE', 'ART:def'] },
         ]], [[
-            { id: 6, token: 'plancton', tag: ['NOM'], lemma: 'plancton' },
-            { id: 7, token: 'frais', tag: ['ADJ'], lemma: 'frais' },
-            { id: 8, token: 'et', tag: ['CON'], lemma: 'et' },
+            { id: 6, token: 'plancton', tag: ['NOM'] },
+            { id: 7, token: 'frais', tag: ['ADJ'] },
+            { id: 8, token: 'et', tag: ['CON'] },
             { id: 9, token: 'de', tag: ['PRE', 'ART:def'] },
-            { id: 10, token: 'hotdog', tag: ['UNK'], lemma: 'hotdog' }]]])
+            { id: 10, token: 'hotdog', tag: ['UNK'] }]]])
         /* eslint-enable object-curly-newline */
             .pipe(ezs('TEEFTExtractTerms', { nounTag: '', adjTag: '' }))
             .pipe(ezs('TEEFTSumUpFrequencies'))

--- a/test/tests.js
+++ b/test/tests.js
@@ -473,7 +473,7 @@ describe('extract terms', () => {
             .pipe(ezs('TEEFTExtractTerms', { nounTag: '', adjTag: '' }))
             // .pipe(ezs('debug'))
             .on('data', (chunk) => {
-                assert(typeof chunk, 'object');
+                assert.equal(typeof chunk, 'object');
                 res.push(chunk);
             })
             .on('end', () => {
@@ -485,6 +485,29 @@ describe('extract terms', () => {
                 assert.equal(res[5].frequency, 2);
                 assert.equal(res[10].length, 11);
                 assert.strictEqual(res[1].frequency, 1); // no undefined
+                done();
+            });
+    });
+
+    it('should return terms from several sentences', (done) => {
+        const res = [];
+        from([[[
+            { token: 'elle', tag: ['PRO:per'] },
+            { token: 'semble', tag: ['VER'] },
+            { token: 'heureuse', tag: ['ADJ'] },
+        ], [
+            { token: 'mais', tag: ['CON'] },
+            { token: 'pas', tag: ['FAKE'] },
+            { token: 'lui', tag: ['PRO'] },
+        ]]])
+            .pipe(ezs('TEEFTExtractTerms', { nounTag: '', adjTag: '' }))
+            // .pipe(ezs('debug'))
+            .on('data', (chunk) => {
+                assert.equal(typeof chunk, 'object');
+                res.push(chunk);
+            })
+            .on('end', () => {
+                assert.equal(res.length, 8); // One multiterm per sentence (no tags given)
                 done();
             });
     });

--- a/test/tests.js
+++ b/test/tests.js
@@ -14,10 +14,12 @@ describe('tokenize', () => {
                 res = res.concat(chunk);
             })
             .on('end', () => {
-                assert.equal(res.length, 3);
-                assert.equal(res[0], 'aha');
-                assert.equal(res[1], 'blabla');
-                assert.equal(res[2], 'hehe');
+                const firstSentence = res[0];
+                assert(Array.isArray(firstSentence));
+                assert.equal(firstSentence.length, 3);
+                assert.equal(firstSentence[0], 'aha');
+                assert.equal(firstSentence[1], 'blabla');
+                assert.equal(firstSentence[2], 'hehe');
                 done();
             });
     });
@@ -31,30 +33,58 @@ describe('tokenize', () => {
                 res = res.concat(chunk);
             })
             .on('end', () => {
-                assert.equal(res.length, 3);
-                assert.equal(res[0], 'ça');
-                assert.equal(res[1], 'va');
-                assert.equal(res[2], 'héhé');
+                const firstSentence = res[0];
+                assert(Array.isArray(firstSentence));
+                assert.equal(firstSentence.length, 3);
+                assert.equal(firstSentence[0], 'ça');
+                assert.equal(firstSentence[1], 'va');
+                assert.equal(firstSentence[2], 'héhé');
                 done();
             });
     });
 
     it('should remove punctuation characters', (done) => {
         let res = [];
-        from(['ça va? héhé!'])
+        from(['ça va, héhé!'])
             .pipe(ezs('TEEFTTokenize'))
             .on('data', (chunk) => {
                 assert(Array.isArray(chunk));
                 res = res.concat(chunk);
             })
             .on('end', () => {
-                assert.equal(res.length, 3);
-                assert.equal(res[0], 'ça');
-                assert.equal(res[1], 'va');
-                assert.equal(res[2], 'héhé');
+                const firstSentence = res[0];
+                assert(Array.isArray(firstSentence));
+                assert.equal(firstSentence.length, 3);
+                assert.equal(firstSentence[0], 'ça');
+                assert.equal(firstSentence[1], 'va');
+                assert.equal(firstSentence[2], 'héhé');
                 done();
             });
     });
+
+    it('should output as many items as sentences', (done) => {
+        let res = [];
+        from(['ça va?', 'héhé!'])
+            .pipe(ezs('TEEFTTokenize'))
+            .on('data', (chunk) => {
+                assert(Array.isArray(chunk));
+                res = res.concat(chunk);
+            })
+            .on('end', () => {
+                assert.equal(res.length, 2);
+                const firstSentence = res[0];
+                assert(Array.isArray(firstSentence));
+                assert.equal(firstSentence.length, 2);
+                assert.equal(firstSentence[0], 'ça');
+                assert.equal(firstSentence[1], 'va');
+                const secondSentence = res[1];
+                assert(Array.isArray(secondSentence));
+                assert.equal(secondSentence.length, 1);
+                assert.equal(secondSentence[0], 'héhé');
+                done();
+            });
+    });
+
 });
 
 describe('fr-to-tag-lem', () => {

--- a/test/tests.js
+++ b/test/tests.js
@@ -7,13 +7,14 @@ ezs.use(require('../lib'));
 describe('tokenize', () => {
     it('should split ascii simple words', (done) => {
         let res = [];
-        from(['aha blabla hehe'])
+        from([['aha blabla hehe']])
             .pipe(ezs('TEEFTTokenize'))
             .on('data', (chunk) => {
                 assert(Array.isArray(chunk));
                 res = res.concat(chunk);
             })
             .on('end', () => {
+                assert.equal(res.length, 1);
                 const firstSentence = res[0];
                 assert(Array.isArray(firstSentence));
                 assert.equal(firstSentence.length, 3);
@@ -26,13 +27,14 @@ describe('tokenize', () => {
 
     it('should split french simple words', (done) => {
         let res = [];
-        from(['ça va héhé'])
+        from([['ça va héhé']])
             .pipe(ezs('TEEFTTokenize'))
             .on('data', (chunk) => {
                 assert(Array.isArray(chunk));
                 res = res.concat(chunk);
             })
             .on('end', () => {
+                assert.equal(res.length, 1);
                 const firstSentence = res[0];
                 assert(Array.isArray(firstSentence));
                 assert.equal(firstSentence.length, 3);
@@ -45,13 +47,14 @@ describe('tokenize', () => {
 
     it('should remove punctuation characters', (done) => {
         let res = [];
-        from(['ça va, héhé!'])
+        from([['ça va, héhé!']])
             .pipe(ezs('TEEFTTokenize'))
             .on('data', (chunk) => {
                 assert(Array.isArray(chunk));
                 res = res.concat(chunk);
             })
             .on('end', () => {
+                assert.equal(res.length, 1);
                 const firstSentence = res[0];
                 assert(Array.isArray(firstSentence));
                 assert.equal(firstSentence.length, 3);
@@ -64,7 +67,7 @@ describe('tokenize', () => {
 
     it('should output as many items as sentences', (done) => {
         let res = [];
-        from(['ça va?', 'héhé!'])
+        from([['ça va?', 'héhé!']])
             .pipe(ezs('TEEFTTokenize'))
             .on('data', (chunk) => {
                 assert(Array.isArray(chunk));
@@ -816,7 +819,7 @@ describe('natural', () => {
     describe('tag', () => {
         it('should correctly tag a sentence in French', (done) => {
             let res = [];
-            from([['Elle', 'semble', 'se', 'nourrir', 'essentiellement', 'de', 'plancton', 'et', 'de', 'hotdog']])
+            from([[['Elle', 'semble', 'se', 'nourrir', 'essentiellement', 'de', 'plancton', 'et', 'de', 'hotdog']]])
                 .pipe(ezs('TEEFTNaturalTag'))
                 // .pipe(ezs('debug'))
                 .on('data', (chunk) => {
@@ -838,7 +841,7 @@ describe('natural', () => {
 
         it('should correctly tag a sentence in French with accented words', (done) => {
             let res = [];
-            from([['Ça', 'veut', 'sûrement', 'dire', 'qu\'', 'il', 'fut', 'assassiné']])
+            from([[['Ça', 'veut', 'sûrement', 'dire', 'qu\'', 'il', 'fut', 'assassiné']]])
                 .pipe(ezs('TEEFTNaturalTag'))
                 // .pipe(ezs('debug'))
                 .on('data', (chunk) => {
@@ -860,10 +863,10 @@ describe('natural', () => {
 
         it('should correctly tag two sentences in French with accented words', (done) => {
             let res = [];
-            from([
+            from([[
                 ['Ça', 'veut', 'sûrement', 'dire', 'qu\'', 'il', 'fut', 'assassiné'],
                 ['Mais', 'j\'', 'espère', 'que', 'ce', 'n\'', 'était', 'pas', 'grave'],
-            ])
+            ]])
                 .pipe(ezs('TEEFTNaturalTag'))
                 // .pipe(ezs('debug'))
                 .on('data', (chunk) => {

--- a/test/tests.js
+++ b/test/tests.js
@@ -530,7 +530,7 @@ describe('sum up frequencies', () => {
     it('should sum up frequencies when in several chunks', (done) => {
         const res = [];
         /* eslint-disable object-curly-newline */
-        from([[{ id: 0, token: 'elle', tag: ['PRO:per'], lemma: 'elle' },
+        from([[[{ id: 0, token: 'elle', tag: ['PRO:per'], lemma: 'elle' },
             { id: 1, token: 'semble', tag: ['VER'], lemma: 'sembler' },
             { id: 2, token: 'se', tag: ['PRO:per'], lemma: 'se' },
             { id: 3, token: 'nourrir', tag: ['VER'], lemma: 'nourrir' },
@@ -540,12 +540,12 @@ describe('sum up frequencies', () => {
                 lemma: 'essentiellement',
             },
             { id: 5, token: 'de', tag: ['PRE', 'ART:def'], lemma: 'de' },
-        ], [
+        ]], [[
             { id: 6, token: 'plancton', tag: ['NOM'], lemma: 'plancton' },
             { id: 7, token: 'frais', tag: ['ADJ'], lemma: 'frais' },
             { id: 8, token: 'et', tag: ['CON'], lemma: 'et' },
             { id: 9, token: 'de', tag: ['PRE', 'ART:def'], lemma: 'de' },
-            { id: 10, token: 'hotdog', tag: ['UNK'], lemma: 'hotdog' }]])
+            { id: 10, token: 'hotdog', tag: ['UNK'], lemma: 'hotdog' }]]])
         /* eslint-enable object-curly-newline */
             .pipe(ezs('TEEFTExtractTerms', { nounTag: '', adjTag: '' }))
             .pipe(ezs('TEEFTSumUpFrequencies'))
@@ -565,7 +565,7 @@ describe('sum up frequencies', () => {
     it('should sum up frequencies when in several chunks, and no lemma', (done) => {
         const res = [];
         /* eslint-disable object-curly-newline */
-        from([[{ id: 0, token: 'elle', tag: ['PRO:per'], lemma: 'elle' },
+        from([[[{ id: 0, token: 'elle', tag: ['PRO:per'], lemma: 'elle' },
             { id: 1, token: 'semble', tag: ['VER'], lemma: 'sembler' },
             { id: 2, token: 'se', tag: ['PRO:per'], lemma: 'se' },
             { id: 3, token: 'nourrir', tag: ['VER'], lemma: 'nourrir' },
@@ -575,12 +575,12 @@ describe('sum up frequencies', () => {
                 lemma: 'essentiellement',
             },
             { id: 5, token: 'de', tag: ['PRE', 'ART:def'] },
-        ], [
+        ]], [[
             { id: 6, token: 'plancton', tag: ['NOM'], lemma: 'plancton' },
             { id: 7, token: 'frais', tag: ['ADJ'], lemma: 'frais' },
             { id: 8, token: 'et', tag: ['CON'], lemma: 'et' },
             { id: 9, token: 'de', tag: ['PRE', 'ART:def'] },
-            { id: 10, token: 'hotdog', tag: ['UNK'], lemma: 'hotdog' }]])
+            { id: 10, token: 'hotdog', tag: ['UNK'], lemma: 'hotdog' }]]])
         /* eslint-enable object-curly-newline */
             .pipe(ezs('TEEFTExtractTerms', { nounTag: '', adjTag: '' }))
             .pipe(ezs('TEEFTSumUpFrequencies'))

--- a/test/tests.js
+++ b/test/tests.js
@@ -84,7 +84,6 @@ describe('tokenize', () => {
                 done();
             });
     });
-
 });
 
 describe('fr-to-tag-lem', () => {
@@ -817,7 +816,7 @@ describe('natural', () => {
     describe('tag', () => {
         it('should correctly tag a sentence in French', (done) => {
             let res = [];
-            from(['Elle', 'semble', 'se', 'nourrir', 'essentiellement', 'de', 'plancton', 'et', 'de', 'hotdog'])
+            from([['Elle', 'semble', 'se', 'nourrir', 'essentiellement', 'de', 'plancton', 'et', 'de', 'hotdog']])
                 .pipe(ezs('TEEFTNaturalTag'))
                 // .pipe(ezs('debug'))
                 .on('data', (chunk) => {
@@ -826,18 +825,20 @@ describe('natural', () => {
                     res = res.concat(chunk);
                 })
                 .on('end', () => {
-                    assert.equal(res.length, 10);
-                    assert.equal(res[1].token, 'semble');
-                    assert.equal(res[1].tag[0], 'v');
-                    assert.equal(res[4].token, 'essentiellement');
-                    assert.equal(res[4].tag[0], 'adv');
+                    assert.equal(res.length, 1);
+                    const firstSentence = res[0];
+                    assert.equal(firstSentence.length, 10);
+                    assert.equal(firstSentence[1].token, 'semble');
+                    assert.equal(firstSentence[1].tag[0], 'v');
+                    assert.equal(firstSentence[4].token, 'essentiellement');
+                    assert.equal(firstSentence[4].tag[0], 'adv');
                     done();
                 });
         });
 
         it('should correctly tag a sentence in French with accented words', (done) => {
             let res = [];
-            from(['Ça', 'veut', 'sûrement', 'dire', 'qu\'', 'il', 'fut', 'assassiné'])
+            from([['Ça', 'veut', 'sûrement', 'dire', 'qu\'', 'il', 'fut', 'assassiné']])
                 .pipe(ezs('TEEFTNaturalTag'))
                 // .pipe(ezs('debug'))
                 .on('data', (chunk) => {
@@ -846,11 +847,42 @@ describe('natural', () => {
                     res = res.concat(chunk);
                 })
                 .on('end', () => {
-                    assert.equal(res.length, 8);
-                    assert.equal(res[1].token, 'veut');
-                    assert.equal(res[1].tag[0], 'v');
-                    assert.equal(res[2].token, 'sûrement');
-                    assert.equal(res[2].tag[0], 'adv');
+                    assert.equal(res.length, 1);
+                    const firstSentence = res[0];
+                    assert.equal(firstSentence.length, 8);
+                    assert.equal(firstSentence[1].token, 'veut');
+                    assert.equal(firstSentence[1].tag[0], 'v');
+                    assert.equal(firstSentence[2].token, 'sûrement');
+                    assert.equal(firstSentence[2].tag[0], 'adv');
+                    done();
+                });
+        });
+
+        it('should correctly tag two sentences in French with accented words', (done) => {
+            let res = [];
+            from([
+                ['Ça', 'veut', 'sûrement', 'dire', 'qu\'', 'il', 'fut', 'assassiné'],
+                ['Mais', 'j\'', 'espère', 'que', 'ce', 'n\'', 'était', 'pas', 'grave'],
+            ])
+                .pipe(ezs('TEEFTNaturalTag'))
+                // .pipe(ezs('debug'))
+                .on('data', (chunk) => {
+                    assert(chunk);
+                    assert(Array.isArray(chunk));
+                    res = res.concat(chunk);
+                })
+                .on('end', () => {
+                    assert.equal(res.length, 2);
+                    const firstSentence = res[0];
+                    assert.equal(firstSentence.length, 8);
+                    assert.equal(firstSentence[1].token, 'veut');
+                    assert.equal(firstSentence[1].tag[0], 'v');
+                    assert.equal(firstSentence[2].token, 'sûrement');
+                    assert.equal(firstSentence[2].tag[0], 'adv');
+                    const secondSentence = res[1];
+                    assert.equal(secondSentence.length, 9);
+                    assert.equal(secondSentence[0].token, 'Mais');
+                    assert(secondSentence[0].tag);
                     done();
                 });
         });


### PR DESCRIPTION
Ajouter `TEEFTSentenceTokenize` au début du script ne change rien au résultat, parce qu'une fois les phrases tokenizées, les tokens sont un derrière l'autre *dans le même tableau*.

Il faudrait garder les phrases séparées jusqu'au passage dans `TEEFTExtractTerms` (donc modifier `TEEFTTokenize`, `TEEFTNaturalTag`, et `TEEFTExtractTerms`)