### PR TITLE
Create toLowerCase statement

### DIFF
--- a/examples/teeftfr-natural.ezs
+++ b/examples/teeftfr-natural.ezs
@@ -17,6 +17,8 @@ plugin = basics
 plugin = teeftfr
 
 [GetFilesContent]
+[ToLowerCase]
+path = content
 [TEEFTSentenceTokenize]
 [TEEFTTokenize]
 [TEEFTNaturalTag]

--- a/examples/teeftfr-natural.ezs
+++ b/examples/teeftfr-natural.ezs
@@ -8,8 +8,7 @@
 
 # > Note: use jq '[limit(10;.[])]' to get only the 10 first tokens
 
-# > Note: use jq 'map(select(.token == "structuration"))' to select a token
-#             jq '.[] | select(.token == "structuration")' does the same
+# > Note: use jq '.[][].terms[] | select(.token == "structuration")' to select a token
 
 # > Note: use jq 'length' to count the tokens
 

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,7 @@ import TEEFTFilterMultiSpec from './filter-multi-spec';
 import profile from './profile';
 import ListFiles from './list-files';
 import GetFilesContent from './get-files-content';
+import ToLowerCase from './to-lower-case';
 
 export default {
     TEEFTTokenize,
@@ -26,4 +27,5 @@ export default {
     TEEFTFilterMultiSpec,
     ListFiles,
     GetFilesContent,
+    ToLowerCase,
 };

--- a/src/to-lower-case.js
+++ b/src/to-lower-case.js
@@ -1,0 +1,36 @@
+import {
+    assocPath, curry, map, path, pipe, toLower,
+} from 'ramda';
+
+const objPropLower = curry((propPath, obj) => {
+    const propToLowerCase = pipe(
+        path(propPath),
+        toLower,
+    );
+    const str = propToLowerCase(obj);
+    const res = assocPath(propPath, str, obj);
+    return res;
+});
+
+/**
+ * Transform strings to lower case.
+ *
+ * @export
+ * @param {any} data
+ * @param {any} feed
+ * @param {Array<string>}   path    path to the property to modify
+ */
+export default function ToLowerCase(data, feed) {
+    if (this.isLast()) {
+        return feed.close();
+    }
+    const propPath = this.getParam('path', []);
+    let res;
+    if (Array.isArray(data)) {
+        res = map(objPropLower(propPath), data);
+    } else {
+        res = objPropLower(propPath, data);
+    }
+    feed.write(res);
+    feed.end();
+}

--- a/src/to-lower-case.js
+++ b/src/to-lower-case.js
@@ -24,7 +24,8 @@ export default function ToLowerCase(data, feed) {
     if (this.isLast()) {
         return feed.close();
     }
-    const propPath = this.getParam('path', []);
+    const paramPath = this.getParam('path', []);
+    const propPath = Array.isArray(paramPath) ? paramPath : [paramPath];
     let res;
     if (Array.isArray(data)) {
         res = map(objPropLower(propPath), data);

--- a/test/tests.js
+++ b/test/tests.js
@@ -1356,3 +1356,51 @@ describe('filter-multi-spec', () => {
             });
     });
 });
+
+describe('to lower case', () => {
+    it('should work on input by default', (done) => {
+        from(['ÇA DEVRAIT ÊTRE MIS EN BAS DE CASSE!'])
+            .pipe(ezs('ToLowerCase'))
+            .on('data', (text) => {
+                assert.equal(text, 'ça devrait être mis en bas de casse!');
+                done();
+            })
+            .on('error', done);
+    });
+
+    it('should use path to select on which part to work', (done) => {
+        from([{ t: 'This Is My Text' }])
+            .pipe(ezs('ToLowerCase', { path: ['t'] }))
+            .on('data', (text) => {
+                assert.equal(text, 'this is my text');
+                done();
+            })
+            .on('error', done);
+    });
+
+    it('should use path to select in arrays too', (done) => {
+        from([[{ t: 'This Is My Text' }]])
+            .pipe(ezs('ToLowerCase', { path: ['t'] }))
+            .on('data', (text) => {
+                assert.equal(text, 'this is my text');
+                done();
+            })
+            .on('error', done);
+    });
+
+    it('should work on several items', (done) => {
+        const res = [];
+        from([{ content: 'This is Content!' }, { content: 'This too.' }])
+            .pipe(ezs('ToLowerCase', { path: ['content'] }))
+            .on('data', (chunk) => {
+                res.push(chunk);
+            })
+            .on('end', () => {
+                assert.equal(res.length, 2);
+                assert.equal(res[0].content, 'this is content!');
+                assert.equal(res[1].content, 'this too.');
+                done();
+            })
+            .on('error', done);
+    });
+});

--- a/test/tests.js
+++ b/test/tests.js
@@ -1369,20 +1369,34 @@ describe('to lower case', () => {
     });
 
     it('should use path to select on which part to work', (done) => {
+        const res = [];
         from([{ t: 'This Is My Text' }])
             .pipe(ezs('ToLowerCase', { path: ['t'] }))
-            .on('data', (text) => {
-                assert.equal(text, 'this is my text');
+            .on('data', (chunk) => {
+                res.push(chunk);
+            })
+            .on('end', () => {
+                assert.equal(res.length, 1);
+                const obj = res[0];
+                assert.equal(obj.t, 'this is my text');
                 done();
             })
             .on('error', done);
     });
 
     it('should use path to select in arrays too', (done) => {
+        const res = [];
         from([[{ t: 'This Is My Text' }]])
             .pipe(ezs('ToLowerCase', { path: ['t'] }))
-            .on('data', (text) => {
-                assert.equal(text, 'this is my text');
+            .on('data', (chunk) => {
+                res.push(chunk);
+            })
+            .on('end', () => {
+                assert.equal(res.length, 1);
+                const arr = res[0];
+                assert.equal(arr.length, 1);
+                const obj = arr[0];
+                assert.equal(obj.t, 'this is my text');
                 done();
             })
             .on('error', done);
@@ -1397,8 +1411,33 @@ describe('to lower case', () => {
             })
             .on('end', () => {
                 assert.equal(res.length, 2);
-                assert.equal(res[0].content, 'this is content!');
-                assert.equal(res[1].content, 'this too.');
+                const obj1 = res[0];
+                const obj2 = res[1];
+                assert.equal(obj1.content, 'this is content!');
+                assert.equal(obj2.content, 'this too.');
+                done();
+            })
+            .on('error', done);
+    });
+
+    it('should keep other properties', (done) => {
+        const res = [];
+        from([{
+            content: 'This is Content!',
+            other: 1,
+        }, {
+            content: 'This too.',
+            other: 2,
+        }])
+            .pipe(ezs('ToLowerCase', { path: ['content'] }))
+            .on('data', (chunk) => {
+                res.push(chunk);
+            })
+            .on('end', () => {
+                assert.deepStrictEqual(res, [
+                    { content: 'this is content!', other: 1 },
+                    { content: 'this too.', other: 2 },
+                ]);
                 done();
             })
             .on('error', done);


### PR DESCRIPTION
To homogeneize terms' cases, and count frequency on the same term for `Web` and `web`, in `PCU_AC_I2D_V0811.txt`, for example.

```bash
$ echo -n ./examples/data/fr-articles/PCU_AC_I2D_V0811.txt | npx ezs ./examples/teeftfr-natural.ezs | jq '.[][].terms[] | select(.token == "Web")'
{
  "frequency": 7,
  "length": 1,
  "token": "Web",
  "tag": [
    "NOM"
  ],
  "term": "Web",
  "specificity": 0.2058823529411765
}
$ echo -n ./examples/data/fr-articles/PCU_AC_I2D_V0811.txt | npx ezs ./examples/teeftfr-natural.ezs | jq '.[][].terms[] | select(.token == "web")'
{
  "frequency": 16,
  "length": 1,
  "token": "web",
  "tag": [
    "NOM"
  ],
  "term": "web",
  "specificity": 0.4705882352941177
}
```