### PR TITLE
Improve TEEFTTokenize (don't cut on dashes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,9 @@ You can even use [jq](https://stedolan.github.io/jq/) to beautify the JSON in th
     -   [Parameters](#parameters-7)
 -   [TEEFTSumUpFrequencies](#teeftsumupfrequencies)
     -   [Parameters](#parameters-8)
--   [tokenize](#tokenize)
+-   [ToLowerCase](#tolowercase)
+    -   [Parameters](#parameters-9)
+-   [TEEFTTokenize](#teefttokenize)
 
 ### TEEFTExtractTerms
 
@@ -403,10 +405,22 @@ Sums up the frequencies of identical lemmas from different chunks.
 -   `data` **[Stream](https://nodejs.org/api/stream.html)** 
 -   `feed` **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)>** 
 
-### tokenize
+### ToLowerCase
+
+Transform strings to lower case.
+
+#### Parameters
+
+-   `data` **any** 
+-   `feed` **any** 
+-   `path` **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)>** path to the property to modify
+
+### TEEFTTokenize
 
 -   **See: <http://yomguithereal.github.io/talisman/tokenizers/words>**
 
 Extract tokens from an array of documents (objects { path, sentences: \[] }).
 
 Yields an array of documents (objects: { path, sentences: \[\[]] })
+
+> **Warning**: results are surprising on uppercase sentences

--- a/examples/teeftfr.ezs
+++ b/examples/teeftfr.ezs
@@ -21,6 +21,8 @@ plugin = teeftfr
 [ListFiles]
 pattern = *.txt
 [GetFilesContent]
+[ToLowerCase]
+path = content
 [TEEFTSentenceTokenize]
 [TEEFTTokenize]
 [TEEFTNaturalTag]

--- a/src/tokenize.js
+++ b/src/tokenize.js
@@ -1,4 +1,8 @@
 import words from 'talisman/tokenizers/words';
+import { map, replace } from 'ramda';
+
+const hideDash = replace(/-/g, 'xyxyxyxyxyxy');
+const revealDash = map(replace(/xyxyxyxyxyxy/g, '-'));
 
 function TEEFTTokenize(data, feed) {
     if (this.isLast()) {
@@ -9,7 +13,10 @@ function TEEFTTokenize(data, feed) {
 
     const docsOut = docsIn.map(doc => ({
         path: doc.path,
-        sentences: doc.sentences.map(words),
+        sentences: doc.sentences
+            .map(hideDash)
+            .map(words)
+            .map(revealDash),
     }));
     feed.write(docsOut);
     feed.end();
@@ -20,8 +27,11 @@ function TEEFTTokenize(data, feed) {
  *
  * Yields an array of documents (objects: { path, sentences: [[]] })
  *
+ * > **Warning**: results are surprising on uppercase sentences
+ *
  * @see http://yomguithereal.github.io/talisman/tokenizers/words
  * @export
+ * @name TEEFTTokenize
  */
 export default {
     TEEFTTokenize,

--- a/test/tests.js
+++ b/test/tests.js
@@ -109,9 +109,12 @@ describe('tokenize', () => {
         let res = [];
         from([{
             path: '/path/1',
-            sentences: ['Do multi-agent plate-formes use TF-IDF'],
+            // WARNING: TEEFTTokenize does not work well on uppercase
+            // sentences: ['Do multi-agent plate-formes use TF-IDF'],
+            sentences: ['do multi-agent plate-formes use tf-idf'],
         }])
             .pipe(ezs('TEEFTTokenize'))
+            // .pipe(ezs('debug'))
             .on('data', (chunk) => {
                 assert(Array.isArray(chunk));
                 res = res.concat(chunk);

--- a/test/tests.js
+++ b/test/tests.js
@@ -104,6 +104,27 @@ describe('tokenize', () => {
                 done();
             });
     });
+
+    it('should not cut on dashes', (done) => {
+        let res = [];
+        from([{
+            path: '/path/1',
+            sentences: ['Do multi-agent plate-formes use TF-IDF'],
+        }])
+            .pipe(ezs('TEEFTTokenize'))
+            .on('data', (chunk) => {
+                assert(Array.isArray(chunk));
+                res = res.concat(chunk);
+            })
+            .on('end', () => {
+                assert.equal(res.length, 1);
+                assert.equal(res[0].sentences.length, 1);
+                const tokens = res[0].sentences[0];
+                assert.equal(tokens.length, 5);
+                done();
+            })
+            .on('error', done);
+    });
 });
 
 describe('stopwords', () => {


### PR DESCRIPTION
See [docnum1_2013.txt](https://github.com/istex/node-ezs-teeftfr/blob/master/examples/data/fr-articles/docnum1_2013.txt) (`TF-IDF`, `K-PPV`, with `PPV` alone, `TF` alone, `IDF` alone)